### PR TITLE
Normal mode o/O insert at top level

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -346,7 +346,7 @@ endfunction
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i[ ] 
+  normal! 0i  [ ] 
   startinsert!
 endfunction
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -332,21 +332,21 @@ endfunction
 
 " Creates a new item above the current line
 function! VimTodoListsCreateNewItemAbove()
-  normal! O  [ ] 
+  normal! O[ ] 
   startinsert!
 endfunction
 
 
 " Creates a new item below the current line
 function! VimTodoListsCreateNewItemBelow()
-  normal! o  [ ] 
+  normal! o[ ] 
   startinsert!
 endfunction
 
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i  [ ] 
+  normal! 0i[ ] 
   startinsert!
 endfunction
 


### PR DESCRIPTION
Currently, `VimTodoListsCreateNewItemAbove` and `VimTodoListsCreateNewItemBelow` always create items at an indented level.

This remedies that by making sure any list item created via these commands in normal mode are created as top-level items.

`<CR>` continues to create child-level items as that felt most natural to me in my use of this plugin.

This also addresses #15 