### PR TITLE
Feature/automatic dating

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,22 @@ function! VimTodoListsCustomMappings()
 endfunction
 ```
 
+Automatic dating
+----------------
+You can enable automatic dating of items by setting the following in your
+.vimrc:
+
+```
+let g:VimTodoListsDatesEnabled = 1
+```
+
+You can change the format of the date by setting the format variable to a valid
+strftime string like so:
+
+```
+let g:VimTodoListsDatesFormat = "%a %b, %Y"
+```
+
 Future features
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ function! VimTodoListsCustomMappings()
 endfunction
 ```
 
-Automatic dating
-----------------
-You can enable automatic dating of items by setting the following in your
+Automatic date insertion
+------------------------
+You can enable automatic date insertion by setting the following in your
 .vimrc:
 
 ```

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -24,6 +24,12 @@
 " Initializes plugin settings and mappings
 function! VimTodoListsInit()
   set filetype=todo
+  if !exists('g:VimTodoListsDatesEnabled')
+    let g:VimTodoListsDatesEnabled = 0
+  endif
+  if !exists('g:VimTodoListDatesFormat')
+    let g:VimTodoListDatesFormat = "%a %b, %Y"
+  endif
   setlocal tabstop=2
   setlocal shiftwidth=2 expandtab
   setlocal cursorline
@@ -333,21 +339,35 @@ endfunction
 " Creates a new item above the current line
 function! VimTodoListsCreateNewItemAbove()
   normal! O[ ] 
-  startinsert!
+  if(g:VimTodoListsDatesEnabled == 1)
+    normal! ma
+    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListDatesFormat ."')\<CR>)"
+    normal! `a
+  endif
+  startinsert
 endfunction
 
 
 " Creates a new item below the current line
 function! VimTodoListsCreateNewItemBelow()
   normal! o[ ] 
-  startinsert!
+ if(g:VimTodoListsDatesEnabled == 1)
+    normal! ma
+    execute "normal! i\<space>(\<c-r>=strftime('" . g:VimTodoListDatesFormat ."')\<cr>)"
+    normal! `a
+  endif
+  startinsert
 endfunction
-
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i  [ ] 
-  startinsert!
+  normal! 0i [ ] 
+  if(g:VimTodoListsDatesEnabled == 1)
+    normal! ma
+    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListDatesFormat ."')\<CR>)"
+    normal! `a
+  endif
+  startinsert
 endfunction
 
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -27,8 +27,8 @@ function! VimTodoListsInit()
   if !exists('g:VimTodoListsDatesEnabled')
     let g:VimTodoListsDatesEnabled = 0
   endif
-  if !exists('g:VimTodoListDatesFormat')
-    let g:VimTodoListDatesFormat = "%a %b, %Y"
+  if !exists('g:VimTodoListsDatesFormat')
+    let g:VimTodoListsDatesFormat = "%a %b, %Y"
   endif
   setlocal tabstop=2
   setlocal shiftwidth=2 expandtab
@@ -341,7 +341,7 @@ function! VimTodoListsCreateNewItemAbove()
   normal! O[ ] 
   if(g:VimTodoListsDatesEnabled == 1)
     normal! ma
-    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListDatesFormat ."')\<CR>)"
+    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListsDatesFormat ."')\<CR>)"
     normal! `a
   endif
   startinsert
@@ -353,7 +353,7 @@ function! VimTodoListsCreateNewItemBelow()
   normal! o[ ] 
  if(g:VimTodoListsDatesEnabled == 1)
     normal! ma
-    execute "normal! i\<space>(\<c-r>=strftime('" . g:VimTodoListDatesFormat ."')\<cr>)"
+    execute "normal! i\<space>(\<c-r>=strftime('" . g:VimTodoListsDatesFormat ."')\<cr>)"
     normal! `a
   endif
   startinsert
@@ -364,7 +364,7 @@ function! VimTodoListsCreateNewItem()
   normal! 0i [ ] 
   if(g:VimTodoListsDatesEnabled == 1)
     normal! ma
-    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListDatesFormat ."')\<CR>)"
+    execute "normal! i\<space>(\<C-r>=strftime('" . g:VimTodoListsDatesFormat ."')\<CR>)"
     normal! `a
   endif
   startinsert

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -346,7 +346,7 @@ endfunction
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i[ ] 
+  normal! 0i  [ ] 
   startinsert!
 endfunction
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -332,21 +332,21 @@ endfunction
 
 " Creates a new item above the current line
 function! VimTodoListsCreateNewItemAbove()
-  normal! O  [ ] 
+  normal! O[ ] 
   startinsert!
 endfunction
 
 
 " Creates a new item below the current line
 function! VimTodoListsCreateNewItemBelow()
-  normal! o  [ ] 
+  normal! o[ ] 
   startinsert!
 endfunction
 
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i  [ ] 
+  normal! 0i[ ] 
   startinsert!
 endfunction
 


### PR DESCRIPTION
This adds the ability for people to enable automatic dating of line items. This is _disabled_ by default.

This feature can be enabled by adding the following line to your `.vimrc`:

`let g:VimTodoListsDatesEnabled = 1`

You can customize the format of the date by setting the following variable to a valid [strftime](http://vimdoc.sourceforge.net/htmldoc/eval.html#strftime()) string like so:

`let g:VimTodoListsDatesFormat = "%a %b, %Y"`
