### PR TITLE
Keep the same indent as the current item on insert

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -354,16 +354,17 @@ function! VimTodoListsAppendDate()
   endif
 endfunction
 
-" Creates a new item above the current line
+" Creates a new item above the current line with the same indent
 function! VimTodoListsCreateNewItemAbove()
-  normal! O- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! O" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 
-
-" Creates a new item below the current line
+" Creates a new item below the current line with the same indent
 function! VimTodoListsCreateNewItemBelow()
-  normal! o- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! o" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -341,7 +341,7 @@ function! VimTodoListsSetItemMode()
   nnoremap <buffer> k :VimTodoListsGoToPreviousItem<CR>
   nnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
   vnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
-  inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
+  inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>:silent call VimTodoListsCreateNewItemBelow()<CR>
   noremap <buffer> <leader>e :silent call VimTodoListsSetNormalMode()<CR>
   nnoremap <buffer> <Tab> :VimTodoListsIncreaseIndent<CR>
   nnoremap <buffer> <S-Tab> :VimTodoListsDecreaseIndent<CR>

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -25,6 +25,11 @@
 function! VimTodoListsInit()
   set filetype=todo
 
+  " Keep the same indent as on the current line or always makes a root item
+  if !exists('g:VimTodoListsKeepSameIndent')
+    let g:VimTodoListsKeepSameIndent = 1
+  endif
+
   if !exists('g:VimTodoListsDatesEnabled')
     let g:VimTodoListsDatesEnabled = 0
   endif
@@ -356,15 +361,23 @@ endfunction
 
 " Creates a new item above the current line with the same indent
 function! VimTodoListsCreateNewItemAbove()
-  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-  execute "normal! O" . l:indentline . "- [ ] "
+  if (g:VimTodoListsKeepSameIndent == 1)
+    let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+    execute "normal! O" . l:indentline . "- [ ] "
+  else
+    normal! O- [ ] 
+  endif
   startinsert!
 endfunction
 
 " Creates a new item below the current line with the same indent
 function! VimTodoListsCreateNewItemBelow()
-  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-  execute "normal! o" . l:indentline . "- [ ] "
+  if (g:VimTodoListsKeepSameIndent == 1)
+    let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+    execute "normal! o" . l:indentline . "- [ ] "
+  else
+    normal! o- [ ] 
+  endif
   startinsert!
 endfunction
 


### PR DESCRIPTION
This PR makes expectation more obvious when a new items appends from some a child item (using 'O' or 'o')

For example:
```
- [ ] Foo text
  - [ ] Bar text
```
Key 'O'/'o' pressed at `Bar text` line gives the root item, like
```
- [ ] Foo text
- [ ] New item
  - [ ] Bar text # the key pressed here
- [ ] New item
```

With this change pressing 'O'/'o' in normal mode and pressing of <CR> will keeps the same indent as in the current line. So, the result of procedure described above will be the following:
```
- [ ] Foo text
  - [ ] New item
  - [ ] Bar text # the key pressed here
  - [ ] New item
```
This behavior could be toggled off via global variable `g:VimTodoListsKeepSameIndent` setted to `0`.
