### PR TITLE
Toggle between creation and modification date of item

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -29,6 +29,11 @@ function! VimTodoListsInit()
     let g:VimTodoListsDatesEnabled = 0
   endif
 
+  " Keep a date of creation or update with a current
+  if !exists('g:VimTodoListsDatesKeepCreation')
+    let g:VimTodoListsDatesKeepCreation = 1
+  endif
+
   if !exists('g:VimTodoListsDatesFormat')
     let g:VimTodoListsDatesFormat = "%X, %d %b %Y"
   endif
@@ -351,6 +356,12 @@ function! VimTodoListsAppendDate()
   if(g:VimTodoListsDatesEnabled == 1)
     let l:date = strftime(g:VimTodoListsDatesFormat)
     execute "s/$/ (" . l:date . ")"
+    " XXX: makes better match up of date
+    if (g:VimTodoListsDatesKeepCreation == 0)
+      silent! execute "s/ ([^)]\\+)\\( ([^)]\\+)\\)$/\\1"
+    else
+      silent! execute "s/\\( ([^)]\\+)\\) ([^)]\\+)$/\\1"
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
This PR's fixup a bug when date could be appended twice or more times.
To reproduce the bug edit an existing item with pressing <CR> key few times.

Behavior which date should be stored for item is configurable.
`let g:VimTodoListsDatesKeepCreation = 1` (or any value not eq to 0) to keep the date of item creation
when the value of config is equal to 0 (zero) timestamp of item will be overwriten with current timestamp.