### PR TITLE
Allow enter key on keypad to create new list item

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -337,6 +337,7 @@ function! VimTodoListsSetItemMode()
   nnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
   vnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
   inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
+  inoremap <buffer> <kEnter> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
   noremap <buffer> <leader>e :silent call VimTodoListsSetNormalMode()<CR>
   nnoremap <buffer> <Tab> :VimTodoListsIncreaseIndent<CR>
   nnoremap <buffer> <S-Tab> :VimTodoListsDecreaseIndent<CR>


### PR DESCRIPTION
In gvim hitting enter on the main keyboard creates a new list item but hitting the enter  button on the keypad doesn't.  This patch makes the two keys do the same thing.