### PR TITLE
do not display command for default mappings (fixes #25)

### DIFF
--- a/after/syntax/todo.vim
+++ b/after/syntax/todo.vim
@@ -1,7 +1,7 @@
 "Syntax commands ordering is important due to order of the matching
-syntax match vimTodoListsDone '^\s*- \[X\].*'
-syntax match vimTodoListsNormal '^\s*- \[ \]\s*.*'
-syntax match vimTodoListsImportant '^\s*- \[ \]\s*!.*'
+syntax match vimTodoListsDone '^\s*\* \[X\].*'
+syntax match vimTodoListsNormal '^\s*\* \[ \]\s*.*'
+syntax match vimTodoListsImportant '^\s*\* \[ \]\s*!.*'
 
 highlight link vimTodoListsDone Comment
 highlight link vimTodoListsNormal Normal

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -354,16 +354,17 @@ function! VimTodoListsAppendDate()
   endif
 endfunction
 
-" Creates a new item above the current line
+" Creates a new item above the current line with the same indent
 function! VimTodoListsCreateNewItemAbove()
-  normal! O- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! O" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 
-
-" Creates a new item below the current line
+" Creates a new item below the current line with the same indent
 function! VimTodoListsCreateNewItemBelow()
-  normal! o- [ ] 
+  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+  execute "normal! o" . l:indentline . "- [ ] "
   startinsert!
 endfunction
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -341,7 +341,7 @@ function! VimTodoListsSetItemMode()
   nnoremap <buffer> k :VimTodoListsGoToPreviousItem<CR>
   nnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
   vnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
-  inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
+  inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>:silent call VimTodoListsCreateNewItemBelow()<CR>
   noremap <buffer> <leader>e :silent call VimTodoListsSetNormalMode()<CR>
   nnoremap <buffer> <Tab> :VimTodoListsIncreaseIndent<CR>
   nnoremap <buffer> <S-Tab> :VimTodoListsDecreaseIndent<CR>

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -442,7 +442,7 @@ endfunction
 " Migrates file to new format
 function! VimTodoListsMigrate()
   normal! mz
-  silent! execute ':%s/^\(\s*\)\(\[.\]\)/\1\* \2/'
+  silent! execute ':%s/^\(\s*\)\(- \|\)\(\[.\]\)/\1\* \3/'
   normal! 'z
 endfunction
 
@@ -471,4 +471,3 @@ if !exists('g:vimtodolists_plugin')
   command! -range VimTodoListsIncreaseIndent silent <line1>,<line2>call VimTodoListsIncreaseIndent()
   command! -range VimTodoListsDecreaseIndent silent <line1>,<line2>call VimTodoListsDecreaseIndent()
 endif
-

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -393,7 +393,7 @@ function! VimTodoListsGoToNextItem()
   normal! $
   silent! exec '/^\s*- \[.\]'
   silent! exec 'noh'
-  normal! l
+  normal! 6l
 endfunction
 
 
@@ -402,7 +402,7 @@ function! VimTodoListsGoToPreviousItem()
   normal! 0
   silent! exec '?^\s*- \[.\]'
   silent! exec 'noh'
-  normal! l
+  normal! 6l
 endfunction
 
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -322,28 +322,28 @@ function! VimTodoListsSetNormalMode()
   nunmap <buffer> O
   nunmap <buffer> j
   nunmap <buffer> k
-  nnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
-  vnoremap <buffer> <Space> :'<,'>VimTodoListsToggleItem<CR>
-  noremap <buffer> <leader>e :silent call VimTodoListsSetItemMode()<CR>
+  nnoremap <buffer><silent> <Space> :VimTodoListsToggleItem<CR>
+  vnoremap <buffer><silent> <Space> :'<,'>VimTodoListsToggleItem<CR>
+  noremap <buffer><silent> <leader>e :silent call VimTodoListsSetItemMode()<CR>
 endfunction
 
 
 " Sets mappings for faster item navigation and editing
 function! VimTodoListsSetItemMode()
-  nnoremap <buffer> o :VimTodoListsCreateNewItemBelow<CR>
-  nnoremap <buffer> O :VimTodoListsCreateNewItemAbove<CR>
-  nnoremap <buffer> j :VimTodoListsGoToNextItem<CR>
-  nnoremap <buffer> k :VimTodoListsGoToPreviousItem<CR>
-  nnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
-  vnoremap <buffer> <Space> :VimTodoListsToggleItem<CR>
-  inoremap <buffer> <CR> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
-  noremap <buffer> <leader>e :silent call VimTodoListsSetNormalMode()<CR>
-  nnoremap <buffer> <Tab> :VimTodoListsIncreaseIndent<CR>
-  nnoremap <buffer> <S-Tab> :VimTodoListsDecreaseIndent<CR>
-  vnoremap <buffer> <Tab> :VimTodoListsIncreaseIndent<CR>
-  vnoremap <buffer> <S-Tab> :VimTodoListsDecreaseIndent<CR>
-  inoremap <buffer> <Tab> <ESC>:VimTodoListsIncreaseIndent<CR>A
-  inoremap <buffer> <S-Tab> <ESC>:VimTodoListsDecreaseIndent<CR>A
+  nnoremap <buffer><silent> o :VimTodoListsCreateNewItemBelow<CR>
+  nnoremap <buffer><silent> O :VimTodoListsCreateNewItemAbove<CR>
+  nnoremap <buffer><silent> j :VimTodoListsGoToNextItem<CR>
+  nnoremap <buffer><silent> k :VimTodoListsGoToPreviousItem<CR>
+  nnoremap <buffer><silent> <Space> :VimTodoListsToggleItem<CR>
+  vnoremap <buffer><silent> <Space> :VimTodoListsToggleItem<CR>
+  inoremap <buffer><silent> <CR> <ESC>:call VimTodoListsAppendDate()<CR>A<CR><ESC>:VimTodoListsCreateNewItem<CR>
+  noremap <buffer><silent> <leader>e :silent call VimTodoListsSetNormalMode()<CR>
+  nnoremap <buffer><silent> <Tab> :VimTodoListsIncreaseIndent<CR>
+  nnoremap <buffer><silent> <S-Tab> :VimTodoListsDecreaseIndent<CR>
+  vnoremap <buffer><silent> <Tab> :VimTodoListsIncreaseIndent<CR>
+  vnoremap <buffer><silent> <S-Tab> :VimTodoListsDecreaseIndent<CR>
+  inoremap <buffer><silent> <Tab> <ESC>:VimTodoListsIncreaseIndent<CR>A
+  inoremap <buffer><silent> <S-Tab> <ESC>:VimTodoListsDecreaseIndent<CR>A
 endfunction
 
 " Appends date at the end of the line

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -63,20 +63,20 @@ endfunction
 " Sets the item done
 function! VimTodoListsSetItemDone(lineno)
   let l:line = getline(a:lineno)
-  call setline(a:lineno, substitute(l:line, '^\(\s*- \)\[ \]', '\1[X]', ''))
+  call setline(a:lineno, substitute(l:line, '^\(\s*\* \)\[ \]', '\1[X]', ''))
 endfunction
 
 
 " Sets the item not done
 function! VimTodoListsSetItemNotDone(lineno)
   let l:line = getline(a:lineno)
-  call setline(a:lineno, substitute(l:line, '^\(\s*- \)\[X\]', '\1[ ]', ''))
+  call setline(a:lineno, substitute(l:line, '^\(\s*\* \)\[X\]', '\1[ ]', ''))
 endfunction
 
 
 " Checks that line is a todo list item
 function! VimTodoListsLineIsItem(line)
-  if match(a:line, '^\s*- \[[ X]\].*') != -1
+  if match(a:line, '^\s*\* \[[ X]\].*') != -1
     return 1
   endif
 
@@ -86,7 +86,7 @@ endfunction
 
 " Checks that item is not done
 function! VimTodoListsItemIsNotDone(line)
-  if match(a:line, '^\s*- \[ \].*') != -1
+  if match(a:line, '^\s*\* \[ \].*') != -1
     return 1
   endif
 
@@ -96,7 +96,7 @@ endfunction
 
 " Checks that item is done
 function! VimTodoListsItemIsDone(line)
-  if match(a:line, '^\s*- \[X\].*') != -1
+  if match(a:line, '^\s*\* \[X\].*') != -1
     return 1
   endif
 
@@ -363,9 +363,9 @@ endfunction
 function! VimTodoListsCreateNewItemAbove()
   if (g:VimTodoListsKeepSameIndent == 1)
     let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-    execute "normal! O" . l:indentline . "- [ ] "
+    execute "normal! O" . l:indentline . "* [ ] "
   else
-    normal! O- [ ] 
+    normal! O* [ ] 
   endif
   startinsert!
 endfunction
@@ -374,16 +374,16 @@ endfunction
 function! VimTodoListsCreateNewItemBelow()
   if (g:VimTodoListsKeepSameIndent == 1)
     let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-    execute "normal! o" . l:indentline . "- [ ] "
+    execute "normal! o" . l:indentline . "* [ ] "
   else
-    normal! o- [ ] 
+    normal! o* [ ] 
   endif
   startinsert!
 endfunction
 
 " Creates a new item in the current line
 function! VimTodoListsCreateNewItem()
-  normal! 0i- [ ] 
+  normal! 0i* [ ] 
   startinsert!
 endfunction
 
@@ -391,7 +391,7 @@ endfunction
 " Moves the cursor to the next item
 function! VimTodoListsGoToNextItem()
   normal! $
-  silent! exec '/^\s*- \[.\]'
+  silent! exec '/^\s*\* \[.\]'
   silent! exec 'noh'
   normal! 6l
 endfunction
@@ -400,7 +400,7 @@ endfunction
 " Moves the cursor to the previous item
 function! VimTodoListsGoToPreviousItem()
   normal! 0
-  silent! exec '?^\s*- \[.\]'
+  silent! exec '?^\s*\* \[.\]'
   silent! exec 'noh'
   normal! 6l
 endfunction
@@ -442,7 +442,7 @@ endfunction
 " Migrates file to new format
 function! VimTodoListsMigrate()
   normal! mz
-  silent! execute ':%s/^\(\s*\)\(\[.\]\)/\1- \2/'
+  silent! execute ':%s/^\(\s*\)\(\[.\]\)/\1\* \2/'
   normal! 'z
 endfunction
 

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -458,7 +458,7 @@ if !exists('g:vimtodolists_plugin')
   "Defining auto commands
   augroup vimtodolists_auto_commands
     autocmd!
-    autocmd BufRead,BufNewFile *.todo call VimTodoListsInit()
+    autocmd BufRead,BufNewFile *.todo.md call VimTodoListsInit()
   augroup end
 
   "Defining plugin commands

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -431,12 +431,12 @@ endfunction
 
 " Increases the indent level
 function! VimTodoListsIncreaseIndent()
-  normal! >>
+  normal! >>6l
 endfunction
 
 " Decreases the indent level
 function! VimTodoListsDecreaseIndent()
-  normal! <<
+  normal! <<6l
 endfunction
 
 " Migrates file to new format

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -25,6 +25,11 @@
 function! VimTodoListsInit()
   set filetype=todo
 
+  " Keep the same indent as on the current line or always makes a root item
+  if !exists('g:VimTodoListsKeepSameIndent')
+    let g:VimTodoListsKeepSameIndent = 1
+  endif
+
   if !exists('g:VimTodoListsDatesEnabled')
     let g:VimTodoListsDatesEnabled = 0
   endif
@@ -356,15 +361,23 @@ endfunction
 
 " Creates a new item above the current line with the same indent
 function! VimTodoListsCreateNewItemAbove()
-  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-  execute "normal! O" . l:indentline . "- [ ] "
+  if (g:VimTodoListsKeepSameIndent == 1)
+    let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+    execute "normal! O" . l:indentline . "- [ ] "
+  else
+    normal! O- [ ] 
+  endif
   startinsert!
 endfunction
 
 " Creates a new item below the current line with the same indent
 function! VimTodoListsCreateNewItemBelow()
-  let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
-  execute "normal! o" . l:indentline . "- [ ] "
+  if (g:VimTodoListsKeepSameIndent == 1)
+    let l:indentline = join(map(range(1,indent(line('.'))), '" "'), '')
+    execute "normal! o" . l:indentline . "- [ ] "
+  else
+    normal! o- [ ] 
+  endif
   startinsert!
 endfunction
 


### PR DESCRIPTION
Adding `<silent>` to the mappings makes the commands not show up under the status bar. This fixes Issue #25.