### PR TITLE
add FileType autocmd for todo file type

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -445,6 +445,7 @@ if !exists('g:vimtodolists_plugin')
   augroup vimtodolists_auto_commands
     autocmd!
     autocmd BufRead,BufNewFile *.todo call VimTodoListsInit()
+    autocmd FileType todo call VimTodoListsInit()
   augroup end
 
   "Defining plugin commands


### PR DESCRIPTION
There are some instances (such as when using a the [vipe](https://github.com/madx/moreutils/blob/master/vipe) pipe editor) when it is inconvenient or impossible to name a file with a ```.todo``` extension.

Since this plugin already claims the ```todo``` file type as part of its init process, adding an autocmd to init it when the loaded file's filetype matches ```todo``` seems sensible.

This then allows any file with a filetype modeline to be automatically interpreted as a todo file, and have this plugin loaded, e.g.
```
# vi: ft=todo
- [ ] one
- [ ] two
- [ ] three
```
