### PR TITLE
Add support to automatically apply todo-lists for files named todo.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ directory.
 Usage
 -----
 
-Plugin is automatically applied for files with `.todo.md` extension.
+Plugin is automatically applied for files named `todo.md` or with the `.todo.md` extension.
 
 ##### TODO Items
 

--- a/doc/vim-todo-lists.txt
+++ b/doc/vim-todo-lists.txt
@@ -20,8 +20,8 @@ CONTENTS                                                  *VimTodoListsContents*
 vim-todo-lists plugin is intended for TODO lists management.
 
 Current version contains only key bindings that simplify the navigation
-between TODO list (should have '.todo.md' extension) items, creation and
-update.
+between TODO list (should be named `todo.md` or have `.todo.md` extension) items,
+creation and update.
 
 ==============================================================================
 2. Installation                                       *VimTodoListsInstallation*
@@ -43,7 +43,7 @@ directory.
 ==============================================================================
 3. Usage                                                     *VimTodoListsUsage*
 
-Plugin is automatically applied for files with `.todo.md` extension.
+Plugin is automatically applied for files named `todo.md` or with the `.todo.md` extension.
 
 TODO Items
 ----------

--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -480,7 +480,7 @@ if !exists('g:vimtodolists_plugin')
   "Defining auto commands
   augroup vimtodolists_auto_commands
     autocmd!
-    autocmd BufRead,BufNewFile *.todo.md call VimTodoListsInit()
+    autocmd BufRead,BufNewFile todo.md,*.todo.md call VimTodoListsInit()
     autocmd FileType todo call VimTodoListsInit()
   augroup end
 


### PR DESCRIPTION
This PR adds expands auto-initializing todo lists to files named `todo.md` in addition to those with the `.todo.md` extension.