### PR TITLE
Remove Tab mapping from insert mode

### DIFF
--- a/plugin/vim-todo-lists.vim
+++ b/plugin/vim-todo-lists.vim
@@ -376,8 +376,6 @@ function! VimTodoListsSetItemMode()
   nnoremap <buffer><silent> <S-Tab> :VimTodoListsDecreaseIndent<CR>
   vnoremap <buffer><silent> <Tab> :VimTodoListsIncreaseIndent<CR>
   vnoremap <buffer><silent> <S-Tab> :VimTodoListsDecreaseIndent<CR>
-  inoremap <buffer><silent> <Tab> <ESC>:VimTodoListsIncreaseIndent<CR>A
-  inoremap <buffer><silent> <S-Tab> <ESC>:VimTodoListsDecreaseIndent<CR>A
 endfunction
 
 " Appends date at the end of the line


### PR DESCRIPTION
I think this is a good QOL improvement since the current mappings prevent adding a tab to a todo item and likely also breaks a lot of people's auto-completion mappings. 